### PR TITLE
Update supported Python versions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,7 +11,7 @@ source = reverse_argparse
 
 [report]
 skip_covered = False
-fail_under = 95
+fail_under = 90
 show_missing = True
 exclude_lines =
     pragma: no cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
 
       - name: Check out the commit
@@ -27,19 +27,13 @@ jobs:
         with:
           python-version: ~${{ matrix.version }}
 
-      - name: Add conda to system path
-        run: |
-          # $CONDA is an environment variable pointing to the root of the
-          # miniconda directory.
-          echo $CONDA/bin >> $GITHUB_PATH
-
       - name: Install test dependencies
         run: |
-          conda install pytest pytest-cov
+          python3 -m pip install pytest pytest-cov
 
       - name: Test with pytest
         run: |
-          python -m pytest --cov=reverse_argparse test/
+          python3 -m pytest --cov=reverse_argparse test/
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
@@ -48,8 +42,8 @@ jobs:
 
       - name: Test install
         run: |
-          pip install .
+          python3 -m pip install .
 
       - name: Test uninstall
         run: |
-          pip uninstall -y reverse_argparse
+          python3 -m pip uninstall -y reverse_argparse

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code Style: black](https://img.shields.io/badge/Code%20Style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/reverse_argparse/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/reverse_argparse/master)
-[![Security: Bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
-[![Linting: Pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
+[![Security: Bandit](https://img.shields.io/badge/Security-Bandit-yellow.svg)](https://github.com/PyCQA/bandit)
+[![Linting: Pylint](https://img.shields.io/badge/Linting-Pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 [![Continuous Integration](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml/badge.svg)](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR)](https://codecov.io/gh/sandialabs/reverse_argparse)
+![Python Version](https://img.shields.io/badge/Python-3.8+-blue.svg)
 
 # reverse_argparse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -65,7 +64,7 @@ Issues = "https://github.com/sandialabs/reverse_argparse/issues"
 
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">=3.8"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Changes that can be undone when we remove 3.8 support:
* Change certain type hints to work for 3.8
* Use version guard around `BooleanOptionalAction`

Changes that can be undone when we remove 3.9 support:
* Switch match-case statement to if block.