### PR TITLE
docs: Install the package first

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,8 @@ sphinx:
 # Declare Python requirements for building the documentation.
 python:
   install:
+    - method: pip
+      path: .
     - requirements: requirements.txt
     - requirements: doc/requirements.txt
     - requirements: example/requirements.txt


### PR DESCRIPTION
Try to `pip install .` as part of creating the environment for ReadTheDocs.