### PR TITLE
Update docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -14,4 +14,4 @@ assignees: ''
 
 ## Checklist
 * [ ] Have you read through the [README](README.md)?
-* [ ] Have you searched through [our documentation](https://reverse_argparse.readthedocs.io)?
+* [ ] Have you searched through [our documentation](https://reverse-argparse.readthedocs.io)?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,3 @@ jobs:
       - name: Test uninstall
         run: |
           python3 -m pip uninstall -y reverse_argparse
-
-      - name: Build documentation
-        run: |
-          ./doc/make-html.bash
-
-      - name: Save documentation artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: html
-          path: doc/build/html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -418,7 +418,7 @@ utilize [type-hinting][typing] wherever possible for clarity's sake.
 [docstrings]: https://www.python.org/dev/peps/pep-0257
 [google]: https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
 [rest]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-[docs]: https://reverse_argparse.readthedocs.io
+[docs]: https://reverse-argparse.readthedocs.io
 [sphinx]: https://www.sphinx-doc.org/en/master/
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR)](https://codecov.io/gh/sandialabs/reverse_argparse)
 [![Continuous Integration](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml/badge.svg)](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![ReadTheDocs](https://readthedocs.org/projects/reverse-argparse/badge/?version=latest)](https://reverse-argparse.readthedocs.io/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/reverse-argparse/badge/?version=latest)](https://reverse-argparse.readthedocs.io/en/latest/?badge=latest)
 [![Linting: Pylint](https://img.shields.io/badge/Linting-Pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/reverse_argparse/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/reverse_argparse/master)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ print(unparser.get_pretty_command_line_invocation())
 For more detailed usage and API information, please see
 [our documentation][readthedocs].
 
-[readthedocs]: https://reverse_argparse.readthedocs.io
+[readthedocs]: https://reverse-argparse.readthedocs.io
 
 ## Where to Get Help
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Continuous Integration](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml/badge.svg)](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR)](https://codecov.io/gh/sandialabs/reverse_argparse)
 ![Python Version](https://img.shields.io/badge/Python-3.8+-blue.svg)
+[![ReadTheDocs](https://readthedocs.org/projects/reverse-argparse/badge/?version=latest)](https://reverse-argparse.readthedocs.io/en/latest/)
 
 # reverse_argparse
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Code Style: black](https://img.shields.io/badge/Code%20Style-black-000000.svg)](https://github.com/psf/black)
+[![codecov](https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR)](https://codecov.io/gh/sandialabs/reverse_argparse)
+[![Continuous Integration](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml/badge.svg)](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![ReadTheDocs](https://readthedocs.org/projects/reverse-argparse/badge/?version=latest)](https://reverse-argparse.readthedocs.io/en/latest/)
+[![Linting: Pylint](https://img.shields.io/badge/Linting-Pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/reverse_argparse/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/reverse_argparse/master)
-[![Security: Bandit](https://img.shields.io/badge/Security-Bandit-yellow.svg)](https://github.com/PyCQA/bandit)
-[![Linting: Pylint](https://img.shields.io/badge/Linting-Pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
-[![Continuous Integration](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml/badge.svg)](https://github.com/sandialabs/reverse_argparse/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR)](https://codecov.io/gh/sandialabs/reverse_argparse)
 ![Python Version](https://img.shields.io/badge/Python-3.8+-blue.svg)
-[![ReadTheDocs](https://readthedocs.org/projects/reverse-argparse/badge/?version=latest)](https://reverse-argparse.readthedocs.io/en/latest/)
+[![Security: Bandit](https://img.shields.io/badge/Security-Bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 
 # reverse_argparse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ readme = "README.md"
 keywords = ["argparse", "argument", "parse", "parsing", "command line"]
 repository = "https://github.com/sandialabs/reverse_argparse"
 description = "Generate the effective command line invocation for a script."
-documentation = "https://reverse_argparse.readthedocs.io"
+documentation = "https://reverse-argparse.readthedocs.io"
 authors = [
     "Jason M. Gates <jmgate@sandia.gov>"
 ]


### PR DESCRIPTION
* Update the URL to our documentation on ReadTheDocs.
* Remove the documentation jobs from the GitHub Actions workflow, and instead let ReadTheDocs test the PR.