### PR TITLE
ci: Fix pre-commit auto-update message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
     autofix_prs: false
+    autoupdate_commit_msg: "ci: pre-commit auto-update"
 
 repos:
 


### PR DESCRIPTION
Ensure the commit message used by the pre-commit auto-update bot adheres to the Conventional Commits specification.