### PR TITLE
docs: Add sphinx-copybutton

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for building the `reverse_argparse` documentation.
 
-sphinx>=6.0,<7.0
+sphinx
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-rtd-theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,6 +2,7 @@
 
 sphinx>=6.0,<7.0
 sphinx-autodoc-typehints
+sphinx-copybutton
+sphinx-rtd-theme
 sphinxcontrib-programoutput
 sphinxcontrib-spelling
-sphinx-rtd-theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
     "sphinx_rtd_theme",
     "sphinxcontrib.programoutput",
     "sphinxcontrib.spelling",


### PR DESCRIPTION
Automatically add a button to all code boxes to copy the contents to the clipboard.

Closes #57.