### PR TITLE
Update python-semantic-release configuration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,4 +59,5 @@ jobs:
       - name: Conventional Commits
         uses: taskmedia/action-conventional-commits@v1.1.3
         with:
-          types: "build|chore|ci|docs|feat|fix|perf|style|refactor|test"
+          types: >
+            build|chore|ci|docs|feat|fix|minor|patch|perf|style|refactor|test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,14 @@ skips = ["**/test_*.py"]
 line-length = 79
 
 
+[tool.commitizen]
+name = "cz_customize"
+
+
+[tool.commitizen.customize]
+schema_pattern = "(?s)(build|chore|ci|docs|feat|fix|minor|patch|perf|refactor|style|test|revert)(\\(\\S+\\))?!?:( [^\\n\\r]+)((\\n\\n.*)|(\\s*))?$"
+
+
 [tool.isort]
 profile = "black"
 line_length = 79
@@ -97,3 +105,22 @@ exclude_commit_patterns = [
 [tool.semantic_release.commit_author]
 env = "GIT_COMMIT_AUTHOR"
 default = "semantic-release <semantic-release>"
+
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "minor",
+    "patch",
+    "perf",
+    "refactor",
+    "style",
+    "test",
+]
+minor_tags = ["feat", "minor"]
+patch_tags = ["fix", "patch", "perf"]

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -1,0 +1,11 @@
+{% for type_, commits in release["elements"] | dictsort %}
+### {{ type_ | capitalize if type_ != "ci" else "Continuous Integration" }}
+{%- if type_ != "unknown" %}
+{% for commit in commits -%}
+{%- set summary = commit.message.rstrip().splitlines()[0] -%}
+{%- set details = commit.message.rstrip().splitlines()[2:] -%}
+* {{ summary }} ([`{{ commit.hexsha[:7] }}`]({{ commit.hexsha | commit_hash_url }}))
+{% if details %}
+{% for line in details %}{% if line.strip() %}  {{ line }}{% endif %}
+{% endfor %}{% endif -%}
+{% endfor %}{% endif %}{% endfor %}


### PR DESCRIPTION
Now that `python-semantic-release` allows for [user customization of the release notes template](https://github.com/python-semantic-release/python-semantic-release/pull/736):
* Add a template so our release notes mirror the format of our [CHANGELOG](CHANGELOG.md).
* Add new commit types to allow for automatically bumping the minor or patch version numbers via `python-semantic-release`.
* Change the `commitizen` configuration to allow for these new commit types.

> **Note:**  This MR should bump the patch version number and trigger a new release so we can ensure this functionality is operating as expected.