### PR TITLE
Include badges in ReadTheDocs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,6 +10,43 @@ reverse_argparse
    examples
    reference
 
+|Code Style: black|
+|codecov|
+|Continuous Integration|
+|Contributor Covenant|
+|Documentation Status|
+|Linting: Pylint|
+|OpenSSF Best Practices|
+|pre-commit|
+|pre-commit.ci Status|
+|PyPI Version|
+|Python Version|
+|Security: Bandit|
+
+.. |Code Style: black| image:: https://img.shields.io/badge/Code%20Style-black-000000.svg
+   :target: https://github.com/psf/black
+.. |codecov| image:: https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR
+   :target: https://codecov.io/gh/sandialabs/reverse_argparse
+.. |Continuous Integration| image:: https://github.com/sandialabs/reverse_argparse/actions/workflows/continuous-integration.yml/badge.svg
+   :target: https://github.com/sandialabs/reverse_argparse/actions/workflows/continuous-integration.yml
+.. |Contributor Covenant| image:: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg
+   :target: https://github.com/sandialabs/reverse_argparse/blob/master/CODE_OF_CONDUCT.md
+.. |Documentation Status| image:: https://readthedocs.org/projects/reverse-argparse/badge/?version=latest
+   :target: https://reverse-argparse.readthedocs.io/en/latest/?badge=latest
+.. |Linting: Pylint| image:: https://img.shields.io/badge/Linting-Pylint-yellowgreen
+   :target: https://github.com/pylint-dev/pylint
+.. |OpenSSF Best Practices| image:: https://bestpractices.coreinfrastructure.org/projects/7632/badge
+   :target: https://bestpractices.coreinfrastructure.org/projects/7632
+.. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
+   :target: https://github.com/pre-commit/pre-commit
+.. |pre-commit.ci Status| image:: https://results.pre-commit.ci/badge/github/sandialabs/reverse_argparse/master.svg
+   :target: https://results.pre-commit.ci/latest/github/sandialabs/reverse_argparse/master
+.. |PyPI Version| image:: https://badge.fury.io/py/reverse-argparse.svg
+   :target: https://badge.fury.io/py/reverse-argparse
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.8|3.9|3.10|3.11|3.12-blue.svg
+.. |Security: Bandit| image:: https://img.shields.io/badge/Security-Bandit-yellow.svg
+   :target: https://github.com/PyCQA/bandit
+
 The ``reverse_argparse`` module provides a means of undoing the argument
 parsing provided by :mod:`argparse`.  That is, it can take a
 :class:`argparse.Namespace` of parsed command line arguments, along with the


### PR DESCRIPTION
Include the badges from the README in the index page of our documentation so this information is visible on ReadTheDocs in addition to GitHub and PyPI.

Closes #81.