### PR TITLE
docs: Add coverage job steps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,6 +50,16 @@ jobs:
         run: make spelling
         working-directory: ./doc
 
+      - name: Check documentation coverage
+        run: make coverage
+        working-directory: ./doc
+
+      - name: Archive documentation coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs-coverage-report
+          path: doc/build/coverage/python.txt
+
       - name: Test uninstall
         run: python3 -m pip uninstall -y reverse_argparse
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,7 +14,8 @@ sys.path.append(str(Path.cwd().parents[2].resolve() / "reverse_argparse"))
 
 project = "reverse_argparse"
 copyright = (
-    "2023, National Technology & Engineering Solutions of Sandia, LLC (NTESS)"
+    "2023–2024, National Technology & Engineering Solutions of Sandia, LLC "
+    "(NTESS)"
 )
 author = "Jason M. Gates"
 version = "1.0.6"


### PR DESCRIPTION
Add steps to the CI job to compute the documentation coverage for the package and archive the results.

Closes #55.