### PR TITLE
docs: Update copyright text in source files

### DIFF
--- a/example/basic.py
+++ b/example/basic.py
@@ -2,7 +2,10 @@
 """
 Basic ``reverse_argparse`` functionality.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from argparse import ArgumentParser

--- a/example/default_values.py
+++ b/example/default_values.py
@@ -2,7 +2,10 @@
 """
 How ``reverse_argparse`` handles default values.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 from argparse import ArgumentParser

--- a/example/post_processing.py
+++ b/example/post_processing.py
@@ -2,7 +2,10 @@
 """
 How ``reverse_argparse`` handles post-processing of arguments.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import os

--- a/example/pretty_printing.py
+++ b/example/pretty_printing.py
@@ -2,7 +2,10 @@
 """
 ``reverse_argparse`` pretty-printing functionality.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import os

--- a/example/relative_references.py
+++ b/example/relative_references.py
@@ -2,7 +2,10 @@
 """
 How ``reverse_argparse`` handles relative references.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import os

--- a/example/subparsers.py
+++ b/example/subparsers.py
@@ -2,7 +2,10 @@
 """
 How ``reverse_argparse`` handles subparsers.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import os

--- a/example/test_examples.py
+++ b/example/test_examples.py
@@ -2,7 +2,10 @@
 """
 Run all the examples and ensure their output is correct.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import re

--- a/reverse_argparse/__init__.py
+++ b/reverse_argparse/__init__.py
@@ -4,7 +4,10 @@ The ``reverse_argparse`` package.
 Provide the :class:`ReverseArgumentParser` class and
 :func:`quote_arg_if_necessary` helper function.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 

--- a/reverse_argparse/reverse_argparse.py
+++ b/reverse_argparse/reverse_argparse.py
@@ -7,7 +7,10 @@ that were already parsed via :mod:`argparse`, and the
 :func:`quote_arg_if_necessary` helper function to surround any arguments
 with spaces in them with quotes.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ Setup file for the ``reverse_argparse`` package.
 
 To install, simply ``python3 -m pip install .`` in the repository root.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 import setuptools

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,6 +5,9 @@ This ``__init__.py`` file creates the ``test`` package, such that tests
 can relative-import from modules in the sibling ``reverse_argparse``
 directory.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """

--- a/test/test_reverse_argparse.py
+++ b/test/test_reverse_argparse.py
@@ -2,7 +2,10 @@
 """
 The unit test suite for the ``reverse_argparse`` package.
 
-Copyright The reverse-argparse Authors.
+© 2024 National Technology & Engineering Solutions of Sandia, LLC
+(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+Government retains certain rights in this software.
+
 SPDX-License-Identifier: BSD-3-Clause
 """
 


### PR DESCRIPTION
Per guidance from Sandia Technology Transfer, the recommended text from the Linux Foundation is insufficient for our purposes.