### PR TITLE
docs: Move copyright/license text to comments

### DIFF
--- a/example/basic.py
+++ b/example/basic.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-Basic ``reverse_argparse`` functionality.
+"""Basic ``reverse_argparse`` functionality."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 from argparse import ArgumentParser
 
 from reverse_argparse import ReverseArgumentParser

--- a/example/default_values.py
+++ b/example/default_values.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-How ``reverse_argparse`` handles default values.
+"""How ``reverse_argparse`` handles default values."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 from argparse import ArgumentParser
 
 from reverse_argparse import ReverseArgumentParser

--- a/example/post_processing.py
+++ b/example/post_processing.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-How ``reverse_argparse`` handles post-processing of arguments.
+"""How ``reverse_argparse`` handles post-processing of arguments."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 from argparse import ArgumentParser
 

--- a/example/pretty_printing.py
+++ b/example/pretty_printing.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-``reverse_argparse`` pretty-printing functionality.
+"""``reverse_argparse`` pretty-printing functionality."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 from argparse import ArgumentParser
 

--- a/example/relative_references.py
+++ b/example/relative_references.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-How ``reverse_argparse`` handles relative references.
+"""How ``reverse_argparse`` handles relative references."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 from argparse import ArgumentParser
 

--- a/example/subparsers.py
+++ b/example/subparsers.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-How ``reverse_argparse`` handles subparsers.
+"""How ``reverse_argparse`` handles subparsers."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
 from argparse import ArgumentParser
 

--- a/example/test_examples.py
+++ b/example/test_examples.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""
-Run all the examples and ensure their output is correct.
+"""Run all the examples and ensure their output is correct."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
+
 import re
 import shlex
 import subprocess  # nosec B404

--- a/reverse_argparse/reverse_argparse.py
+++ b/reverse_argparse/reverse_argparse.py
@@ -6,13 +6,13 @@ Defines the :class:`ReverseArgumentParser` class for unparsing arguments
 that were already parsed via :mod:`argparse`, and the
 :func:`quote_arg_if_necessary` helper function to surround any arguments
 with spaces in them with quotes.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
 
 import re
 import sys

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@
 Setup file for the ``reverse_argparse`` package.
 
 To install, simply ``python3 -m pip install .`` in the repository root.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
+
 import setuptools
 
 if __name__ == "__main__":

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,10 +4,10 @@ Create the ``test`` package.
 This ``__init__.py`` file creates the ``test`` package, such that tests
 can relative-import from modules in the sibling ``reverse_argparse``
 directory.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause

--- a/test/test_reverse_argparse.py
+++ b/test/test_reverse_argparse.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
-"""
-The unit test suite for the ``reverse_argparse`` package.
+"""The unit test suite for the ``reverse_argparse`` package."""
 
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
 
-SPDX-License-Identifier: BSD-3-Clause
-"""
+# SPDX-License-Identifier: BSD-3-Clause
 
 import shlex
 import sys


### PR DESCRIPTION
**Type:  Documentation**

## Description
In all source files, move the copyright and license text from the module docstring to comments immediately below it.  This is to avoid processing this text when Sphinx is automatically generating documentation from docstrings.