### PR TITLE
docs: Add code lines badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Lines of code](https://sloc.xyz/github/sandialabs/reverse_argparse/?category=code)
 [![codecov](https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR)](https://codecov.io/gh/sandialabs/reverse_argparse)
 [![CodeFactor](https://www.codefactor.io/repository/github/sandialabs/reverse_argparse/badge/master)](https://www.codefactor.io/repository/github/sandialabs/reverse_argparse/overview/master)
 [![CodeQL](https://github.com/sandialabs/reverse_argparse/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/sandialabs/reverse_argparse/actions/workflows/github-code-scanning/codeql)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,6 +10,7 @@ reverse_argparse
    examples
    reference
 
+|Code lines|
 |codecov|
 |CodeFactor|
 |CodeQL|
@@ -31,6 +32,7 @@ reverse_argparse
 |Python Version|
 |Ruff|
 
+.. |Code lines| image:: https://sloc.xyz/github/sandialabs/reverse_argparse/?category=code
 .. |codecov| image:: https://codecov.io/gh/sandialabs/reverse_argparse/branch/master/graph/badge.svg?token=FmDStZ6FVR
    :target: https://codecov.io/gh/sandialabs/reverse_argparse
 .. |CodeFactor| image:: https://www.codefactor.io/repository/github/sandialabs/reverse_argparse/badge/master


### PR DESCRIPTION
**Type:  Documentation**

## Description
Add badge indicating the lines of code in the repository.

> **Note:**  The badge doesn't display on ReadTheDocs when viewed from a Sandia network, because Sandia flags the site generating the badge as suspicious.  The badge displays fine on ReadTheDocs when viewed from the open internet, and the badge on GitHub works just fine regardless.

## Related Issues/PRs
Closes #115.