### PR TITLE
docs: Fix license/copyright text in file

### DIFF
--- a/reverse_argparse/__init__.py
+++ b/reverse_argparse/__init__.py
@@ -3,13 +3,13 @@ The ``reverse_argparse`` package.
 
 Provide the :class:`ReverseArgumentParser` class and
 :func:`quote_arg_if_necessary` helper function.
-
-© 2024 National Technology & Engineering Solutions of Sandia, LLC
-(NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
-Government retains certain rights in this software.
-
-SPDX-License-Identifier: BSD-3-Clause
 """
+
+# © 2024 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS).  Under the terms of Contract DE-NA0003525 with NTESS, the
+# U.S. Government retains certain rights in this software.
+
+# SPDX-License-Identifier: BSD-3-Clause
 
 from .reverse_argparse import ReverseArgumentParser, quote_arg_if_necessary
 


### PR DESCRIPTION
**Type:  Documentation**

## Description
Should have been included in b3553415da40949f9ce496ca1363cb69424da791, but was overlooked.

## Related Issues/PRs
Follow-on to #98.