### PR TITLE
docs: Slight tweaks to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,6 @@ The checks we perform are the following:
 * Ensure files don't contain merge conflict strings.
 * Ensure files end with a single blank line.
 * Ensure we only use Unix line endings.
-* Ensure test files are correctly named.
 * Trim trailing whitespace.
 * Ensure we use [type-hinting][typing].
 * Check for common mistakes in [reStructuredText][rest] in our documentation.
@@ -133,8 +132,6 @@ search for and install them.  These are the ones we recommend:
 * **Conventional Commits:**  Adhere to the [Conventional Commits][conventional]
   specification for commit messages.
 * **Coverage Gutters:**  Display test coverage in the editor.
-* **GitLab Workflow:**  Integrate GitLab issues, merge requests, and pipelines
-  into VS Code.
 * **GitLens — Git supercharged:**  Integrate some of the powerful features of
   [GitKraken][kraken] into VS Code.
 * **IntelliCode:**  AI-assisted development features.
@@ -235,10 +232,6 @@ Consider adding the following snippets:
   The line at 79 characters is to remind you of the maximum line length, and
   the one at 72 characters is to remind you of the maximum line length for
   comments and docstrings (see [PEP8][pep8]).
-* To prevent VS Code from sending telemetry data off-site, add
-  ```json
-  "redhat.telemetry.enabled": false,
-  ```
 * If you'd like the UI to preserve the scope that you're currently editing at
   the top of the file as you scroll through it, you can add
   ```json
@@ -468,14 +461,14 @@ work into logical, working commits.  Use the **Conventional Commits** extension
 for VS Code (or something similar) to ensure your commit messages adhere to the
 [Conventional Commits specification][conventional].
 
-Feel free to commit and push small chunks early and often and then use `git
-rebase -i` to reorganize your commits before sharing.
+Feel free to commit and push small chunks early and often and then use
+interactive rebase to reorganize your commits before sharing.
 
 > **Note:**  If you rebase a branch that's already been pushed to a remote,
-> you'll wind up changing the history, which will require a force push with
-> `git push origin +<branch-name>`.  That is permissible (even encouraged), but
-> if you've had one or more reviewers or collaborators working with you on the
-> branch, *get their buy-in first* before doing a force push.
+> you'll wind up changing the history, which will require a force push.  That
+> is permissible (even encouraged), but if you've had one or more reviewers or
+> collaborators working with you on the branch, *get their buy-in first* before
+> doing a force push.
 
 ### When Work is Complete
 


### PR DESCRIPTION
Just some minor tweaks to the contributing guidelines I ran across when preparing a new repository for open sourcing.
* The test file naming is handled behind the scenes by another pre-commit check.
* No need to recommend the GitLab extension, since this is now on GitHub.
* No need to worry about external vs internal since this is hosted externally.
* Remove specific git commands&mdash;if you need to force-push/pull, you should be able to figure it out.