### PR TITLE
ci: Don't fix Ruff issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       rev: v0.4.10
       hooks:
         - id: ruff
-          args: [ --fix ]
         - id: ruff-format
 
     - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
**Type:  Task**

## Description
Remove the `--fix` argument from the `ruff` check in the pre-commit configuration.

## Motivation
We don't want automated commits pushed to PRs, because we want to encourage contributors to clean up their branches before merging.  Additionally, when pre-commit doesn't automatically fix files, it shows the user what the issues are, thereby training them to avoid them in the future.