### PR TITLE
chore: Tweak dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,19 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      github-actions-dependencies:
+        applies-to: version-updates
 
   - package-ecosystem: pip
-    directory: /doc
+    directories:
+      - /
+      - /doc
+      - /example
+      - /test
     schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /example
-    schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /test
-    schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      python-dependencies:
+        applies-to: version-updates


### PR DESCRIPTION
**Type:  Task**

## Description
Run weekly instead of daily, and group updates into a single PR for each packaging ecosystem.

## Motivation
Just tired of so many dependency updates.  Our existing configuration was automatically generated by the @step-security-bot, following best practices defined by the OpenSSF, *but* I'm not convinced updating all dependencies on a potentially daily basis via separate PRs is the best thing to do.

## Implementation Details
Followed [this documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).
