### PR TITLE
chore!: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
 
       - name: Harden Runner

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/reverse_argparse/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/reverse_argparse/master)
 [![PyPI - Version](https://img.shields.io/pypi/v/reverse-argparse?label=PyPI)](https://pypi.org/project/reverse-argparse/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/reverse-argparse?label=PyPI%20downloads)
-![Python Version](https://img.shields.io/badge/Python-3.8|3.9|3.10|3.11|3.12-blue.svg)
+![Python Version](https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12-blue.svg)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 # reverse_argparse

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -66,7 +66,7 @@ reverse_argparse
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/reverse-argparse?label=PyPI
    :target: https://pypi.org/project/reverse-argparse/
 .. |PyPI Downloads| image:: https://img.shields.io/pypi/dm/reverse-argparse?label=PyPI%20downloads
-.. |Python Version| image:: https://img.shields.io/badge/Python-3.8|3.9|3.10|3.11|3.12-blue.svg
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12-blue.svg
 .. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/reverse_argparse/reverse_argparse.py
+++ b/reverse_argparse/reverse_argparse.py
@@ -14,12 +14,10 @@ with spaces in them with quotes.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import re
-import sys
 from argparse import SUPPRESS, Action, ArgumentParser, Namespace
-from typing import List, Sequence
+from typing import Sequence
 
 
-BOOLEAN_OPTIONAL_ACTION_MINOR_VERSION = 9
 SHORT_OPTION_LENGTH = 2
 
 
@@ -38,20 +36,20 @@ class ReverseArgumentParser:
     such that they're able to reproduce a prior run of a script exactly.
 
     Attributes:
-        _args (List[str]):  The list of arguments corresponding to each
+        _args (list[str]):  The list of arguments corresponding to each
             :class:`argparse.Action` in the given parser, which is built
             up as the arguments are unparsed.
         _indent (int):  The number of spaces with which to indent
             subsequent lines when pretty-printing the effective command
             line invocation.
         _namespace (Namespace):  The parsed arguments.
-        _parsers (List[argparse.ArgumentParser]):  The parser that was
+        _parsers (list[argparse.ArgumentParser]):  The parser that was
             used to generate the parsed arguments.  This is a ``list``
             (conceptually a stack) to allow for sub-parsers, so the
             outer-most parser is the first item in the list, and
             sub-parsers are pushed onto and popped off of the stack as
             they are processed.
-        _unparsed (List[bool]):  A list in which the elements indicate
+        _unparsed (list[bool]):  A list in which the elements indicate
             whether the corresponding parser in :attr:`parsers` has been
             unparsed.
     """
@@ -136,10 +134,7 @@ class ReverseArgumentParser:
             self._unparse_sub_parsers_action(action)
         elif action_type == "_VersionAction":  # pragma: no cover
             return
-        elif (
-            action_type == "BooleanOptionalAction"
-            and sys.version_info.minor >= BOOLEAN_OPTIONAL_ACTION_MINOR_VERSION
-        ):
+        elif action_type == "BooleanOptionalAction":
             self._unparse_boolean_optional_action(action)
         else:  # pragma: no cover
             message = (
@@ -202,7 +197,7 @@ class ReverseArgumentParser:
 
     def _get_long_option_strings(
         self, option_strings: Sequence[str]
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Get the long options from a list of options strings.
 
@@ -224,7 +219,7 @@ class ReverseArgumentParser:
 
     def _get_short_option_strings(
         self, option_strings: Sequence[str]
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Get the short options from a list of options strings.
 
@@ -278,7 +273,7 @@ class ReverseArgumentParser:
                 return short_options[0]
         return ""
 
-    def _append_list_of_list_of_args(self, args: List[List[str]]) -> None:
+    def _append_list_of_list_of_args(self, args: list[list[str]]) -> None:
         """
         Append to the list of unparsed arguments.
 
@@ -293,7 +288,7 @@ class ReverseArgumentParser:
         for line in args:
             self._args.append(self._indent_str + " ".join(line))
 
-    def _append_list_of_args(self, args: List[str]) -> None:
+    def _append_list_of_args(self, args: list[str]) -> None:
         """
         Append to the list of unparsed arguments.
 


### PR DESCRIPTION
**Type:  Task**

## Description
* Use the type-hinting provided out of the box in 3.9.
* Remove version guards around `argparse.BooleanOptionalAction`.
* Update documentation and CI accordingly.

## Related Issues/PRs
* Closes #15.
* After this is merged, #242 should pass CI.

## Motivation
Python 3.8 is no longer supported by the community.

## Summary by Sourcery

Drop support for Python 3.8, leveraging Python 3.9 features such as built-in type hinting and removing version guards for BooleanOptionalAction. Update CI and documentation to align with the new minimum Python version requirement.

Enhancements:
- Utilize Python 3.9's built-in type hinting capabilities.

CI:
- Update CI configuration to remove testing for Python 3.8.

Documentation:
- Update documentation to reflect the removal of Python 3.8 support.

Chores:
- Drop support for Python 3.8 across the codebase.