### PR TITLE
docs: Switch to `project_copyright`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,7 +13,7 @@ sys.path.append(str(Path.cwd().parents[2].resolve() / "reverse_argparse"))
 # -- Project information ------------------------------------------------------
 
 project = "reverse_argparse"
-copyright = (  # noqa: A001
+project_copyright = (
     "2023, National Technology & Engineering Solutions of Sandia, LLC (NTESS)"
 )
 author = "Jason M. Gates"


### PR DESCRIPTION
**Type:  Documentation**

## Description
Using this alias means we're no longer overshadowing the `copyright` built-in, so we can remove the comment to ignore that Ruff linting rule.

## Summary by Sourcery

Documentation:
- Replaced the usage of the built-in `copyright` with `project_copyright`.