### PR TITLE
patch: Replace deprecated GitHub Action

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Python Semantic Release
       id: release
-      uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # master
+      uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # v9.21.1
       with:
         github_token: ${{ secrets.GH_TOKEN }}
 
@@ -38,7 +38,7 @@ jobs:
       if: steps.release.outputs.released == 'true'
 
     - name: Publish to GitHub Releases
-      uses: python-semantic-release/upload-to-gh-release@0a92b5d7ebfc15a84f9801ebd1bf706343d43711 # main
+      uses: python-semantic-release/publish-action@1aa9f41fac5d531e6764e1991b536783337f3a56 # v9.21.1
       if: steps.release.outputs.released == 'true'
       with:
         github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
**Type:  Task**

## Description
Marking this as a patch release to test out the new action and make sure it works.

## Related Issues/PRs
Closes #255.

## Motivation
1. We don't want to use deprecated integrations.
2. This should cryptographically sign the release assets when uploading them.  We already provided signed releases via PyPI and conda-forge, but now we'll have signed releases on GitHub as well.

## Summary by Sourcery

CI:
- Update semantic-release and publish-to-GitHub-Release actions to python-semantic-release@v9.21.1 to replace deprecated integrations