### PR TITLE
patch: Omit pre-commit updates from CHANGELOG

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ match = "master"
 exclude_commit_patterns = [
     "chore.*deps.*Bump",
     "Merge pull request",
-    "pre-commit auto-update",
+    "ci.*pre-commit.*auto-update",
 ]
 
 


### PR DESCRIPTION
**Type:  Task**

## Description
I thought 1aa9022a7c7796e85e342382f67b02434d4b544b was sufficient for this, but apparently not.  Trying again.

## Related Issues/PRs
Follows #296.

## Motivation
Just want a cleaner CHANGELOG.

## Summary by Sourcery

Chores:
- Adjust the exclude_commit_patterns regex in pyproject.toml to "ci.*pre-commit.*auto-update" instead of the fixed string