### PR TITLE
patch: Sign semantic release commits/tags

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -31,7 +31,11 @@ jobs:
       id: release
       uses: python-semantic-release/python-semantic-release@1a324000f2251a9e722e77b128bf72712653813f # v10.0.2
       with:
+        git_committer_email: "reverse-argparse-semantic-release@sandia.gov"
+        git_committer_name: "semantic-release"
         github_token: ${{ secrets.GH_TOKEN }}
+        ssh_private_signing_key: ${{ secrets.SEMANTIC_RELEASE_PRIVATE_KEY }}
+        ssh_public_signing_key: ${{ secrets.SEMANTIC_RELEASE_PUBLIC_KEY }}
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1


### PR DESCRIPTION
**Type:  Task**

## Description
This PR adds commit and tag signing to changes made by python-semantic-release in CI.

## Related Issues/PRs
Thought #255 and #295 would take care of this automatically, but they didn't.

Finally figured out how to do this when researching #260.

## Motivation
Signing releases means we have a better security posture.

## Implementation Details
* Generate a SSH key pair locally.
* Add the public key as a deploy key to your repository with write access.
* Store both the public and private keys as GitHub Actions repository secrets.
* Make the workflow changes shown in the diff such that python-semantic-release can use the keys for signing.

## Testing
I modified the configuration to allow python-semantic-release to create a new release commit and tag on this branch and verified that both were signed.

## Summary by Sourcery

Enable commit and tag signing for releases by configuring python-semantic-release in CI to use SSH signing keys.

New Features:
- Add commit and tag signing to semantic-release

CI:
- Configure GitHub Actions workflow to provide SSH keys and committer identity for signing