### PR TITLE
Add SLSA provenance

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -39,6 +39,13 @@ jobs:
         ssh_private_signing_key: ${{ secrets.SEMANTIC_RELEASE_PRIVATE_KEY }}
         ssh_public_signing_key: ${{ secrets.SEMANTIC_RELEASE_PUBLIC_KEY }}
 
+    - name: Hash Build Artifacts
+      if: steps.release.outputs.released == 'true'
+      id: hash
+      run: |
+        cd dist
+        echo "hashes=$(find . -type f -exec sha256sum {} + | sort | base64 | tr -d '\n')" >> "$GITHUB_OUTPUT"
+
     - name: Upload Build Artifacts
       if: steps.release.outputs.released == 'true'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -47,12 +54,24 @@ jobs:
         path: dist/
 
     outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
       released: ${{ steps.release.outputs.released }}
+
+  provenance:
+    needs: release
+    if: ${{ needs.release.outputs.released == 'true' }}
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
 
   publish:
     runs-on: ubuntu-latest
-    needs: release
-    if: ${{ needs.release.outputs.released == 'true' }}
+    needs: [release, provenance]
+    if: ${{ needs.release.outputs.released == 'true' && needs.provenance.outputs.outcome == 'success' }}
     environment: release
     steps:
     - name: Harden Runner
@@ -65,10 +84,16 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.GH_TOKEN }}
 
-    - name: Download Artifacts
+    - name: Download Build Artifacts
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: dist
+        path: dist
+
+    - name: Download Provenance
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: ${{ needs.provenance.outputs.provenance-name }}
         path: dist
 
     - name: Publish to PyPI


### PR DESCRIPTION
**Type:  Task**

## Motivation
This should satisfy the [Signed Releases](https://github.com/ossf/scorecard/blob/ab2f6e92482462fe66246d9e32f642855a691dc1/docs/checks.md#signed-releases) Scorcard check.

## Commits
1. **ci: Subdivide release job** (60bca1015cc44de46af03b17c5a8a55582cd32aa)

   This is needed because the SLSA provenance reusable workflow cannot be used as a step within a job, but must be used as a job on its own.  This commit therefore subdivides the `release` job into a `release` job, which runs `python-semantic-release` to create a new release, if applicable, and then a `publish` job, to publish the release to PyPI and GitHub Releases, if one was created.  We'll then be able to insert the SLSA provenance job between the two.
1. **patch: Add SLSA provenance to release assets** (48a6b53c1f4b64e619828d7d95d4c1ff50ea4e10)

   See https://slsa.dev/ for motivation.

   Creating a patch release to ensure these additions to the automated release process work.

   Closes #260.

## Implementation Details
I followed the guidelines for generating [Provenance for Python](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#provenance-for-python), and read through the [reusable workflow](https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/workflows/generator_generic_slsa3.yml) to get a feel for what it was doing, but ultimately this just required a lot of experimentation to finally fit the puzzle pieces together correctly.

## Screenshots/Recordings
From [this job](https://github.com/sandialabs/reverse_argparse/actions/runs/16297437471/job/46022875852):

<img width="509" height="242" alt="Screenshot 2025-07-15 at 9 33 21 AM" src="https://github.com/user-attachments/assets/6aba4ea4-b60b-49b6-84aa-ef789bb6449a" />

From [this Rekor record](https://search.sigstore.dev/?logIndex=274928506):

<img width="1166" height="1277" alt="Screenshot 2025-07-15 at 9 34 29 AM" src="https://github.com/user-attachments/assets/3e746479-4d34-4603-858a-39fb9cc5597d" />

## Testing
I added a dummy commit to allow the `semantic-release` workflow to trigger on this branch, and made it such that no commits/tags were pushed to the repo, and no releases were uploaded anywhere, to see what would have happened if it were running for real.

## Summary by Sourcery

Integrate SLSA provenance generation into the semantic-release CI workflow by splitting the release job, hashing and uploading build artifacts, running a dedicated provenance job using the SLSA GitHub generator, and gating the publish step on successful provenance creation.

CI:
- Split the existing `release` job into separate `release`, `provenance`, and `publish` jobs under a shared concurrency group
- Add steps to hash and upload build artifacts after release and download them in downstream jobs
- Introduce a `provenance` job that uses the SLSA GitHub generator to produce signed provenance for Python artifacts
- Require successful provenance generation before publishing releases to PyPI and GitHub