### PR TITLE
fix: Set sufficient permissions for publish job

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -73,6 +73,9 @@ jobs:
     needs: [release, provenance]
     if: ${{ needs.release.outputs.released == 'true' && needs.provenance.outputs.outcome == 'success' }}
     environment: release
+    permissions:
+      id-token: write
+
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2


### PR DESCRIPTION
**Type:  Bug**

## Description
When running the upload to PyPI action, we ran into:

    Error:  Trusted publishing exchange failure:
    OpenID Connect token retrieval failed:  GitHub:  missing or
    insufficient OIDC token permissions, the
    ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset

    This generally indicates a workflow configuration error, such as
    insufficient permissions.  Make sure that your workflow has
    `id-token: write` configured at the job level, e.g.:

    ```yaml
    permissions:
      id-token: write
    ```

## Related Issues/PRs
Problem caused by #315 (60bca1015cc44de46af03b17c5a8a55582cd32aa).

