### PR TITLE
fix: Rework release publishing

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -99,10 +99,13 @@ jobs:
         name: ${{ needs.provenance.outputs.provenance-name }}
         path: dist
 
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
-
     - name: Publish to GitHub Releases
       uses: python-semantic-release/publish-action@b717f67f7e7e9f709357bce5a542846503ce46ec # v10.2.0
       with:
         github_token: ${{ secrets.GH_TOKEN }}
+
+    - name: Remove Provenance for PyPI Upload
+      run: rm -f dist/${{ needs.provenance.outputs.provenance-name }}
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1


### PR DESCRIPTION
**Type:  Bug**

## Description
The PyPI upload failed with:

    Checking dist/reverse_argparse-2.0.8-py3-none-any.whl: PASSED
    Checking dist/multiple.intoto.jsonl: ERROR    InvalidDistribution:
    Unknown distribution format:
             'multiple.intoto.jsonl'

I suppose the provenance can't be included in the `dist` directory for the PyPI upload, but it needs to be in there for python-semantic-release publish to GitHub Releases action.  This commit reorders things, such that we publish to GitHub first, and save PyPI for last, and between the two we remove the provenance from the `dist` directory.  Hopefully this works.

## Related Issues/PRs
Problems created in #315 and #316.

## Summary by Sourcery

Reorder the GitHub Actions release workflow to publish to GitHub Releases first, remove the provenance file from the distribution, and then publish to PyPI to prevent invalid distribution errors

Bug Fixes:
- Remove provenance file before PyPI upload to fix invalid distribution error

CI:
- Reorder semantic-release.yml to publish to GitHub Releases prior to PyPI
- Add a step to remove the provenance file from dist before the PyPI publish