### PR TITLE
patch:  Drop support for Python 3.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
 
       - name: Harden Runner

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the "doc/" directory with Sphinx.
 sphinx:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![pre-commit.ci Status](https://results.pre-commit.ci/badge/github/sandialabs/reverse_argparse/master.svg)](https://results.pre-commit.ci/latest/github/sandialabs/reverse_argparse/master)
 [![PyPI - Version](https://img.shields.io/pypi/v/reverse-argparse?label=PyPI)](https://pypi.org/project/reverse-argparse/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/reverse-argparse?label=PyPI%20downloads)
-![Python Version](https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12|3.13-blue.svg)
+![Python Version](https://img.shields.io/badge/Python-3.10|3.11|3.12|3.13|3.14-blue.svg)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 # reverse_argparse

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -66,7 +66,7 @@ reverse_argparse
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/reverse-argparse?label=PyPI
    :target: https://pypi.org/project/reverse-argparse/
 .. |PyPI Downloads| image:: https://img.shields.io/pypi/dm/reverse-argparse?label=PyPI%20downloads
-.. |Python Version| image:: https://img.shields.io/badge/Python-3.9|3.10|3.11|3.12|3.13-blue.svg
+.. |Python Version| image:: https://img.shields.io/badge/Python-3.10|3.11|3.12|3.13|3.14-blue.svg
 .. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Documentation",
@@ -44,7 +44,7 @@ Issues = "https://github.com/sandialabs/reverse_argparse/issues"
 
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 
 
 [tool.poetry.dev-dependencies]

--- a/reverse_argparse/reverse_argparse.py
+++ b/reverse_argparse/reverse_argparse.py
@@ -114,36 +114,37 @@ class ReverseArgumentParser:
             or self._arg_is_default_and_help_is_suppressed(action)
         ):
             return
-        if action_type == "_AppendAction":
-            self._unparse_append_action(action)
-        elif action_type == "_AppendConstAction":
-            self._unparse_append_const_action(action)
-        elif action_type == "_CountAction":
-            self._unparse_count_action(action)
-        elif action_type == "_ExtendAction":
-            self._unparse_extend_action(action)
-        elif action_type == "_HelpAction":  # pragma: no cover
-            return
-        elif action_type == "_StoreAction":
-            self._unparse_store_action(action)
-        elif action_type == "_StoreConstAction":
-            self._unparse_store_const_action(action)
-        elif action_type == "_StoreFalseAction":
-            self._unparse_store_false_action(action)
-        elif action_type == "_StoreTrueAction":
-            self._unparse_store_true_action(action)
-        elif action_type == "_SubParsersAction":
-            self._unparse_sub_parsers_action(action)
-        elif action_type == "_VersionAction":  # pragma: no cover
-            return
-        elif action_type == "BooleanOptionalAction":
-            self._unparse_boolean_optional_action(action)
-        else:  # pragma: no cover
-            message = (
-                f"{self.__class__.__name__} does not yet support the "
-                f"unparsing of {action_type} objects."
-            )
-            raise NotImplementedError(message)
+        match action_type:
+            case "_AppendAction":
+                self._unparse_append_action(action)
+            case "_AppendConstAction":
+                self._unparse_append_const_action(action)
+            case "_CountAction":
+                self._unparse_count_action(action)
+            case "_ExtendAction":
+                self._unparse_extend_action(action)
+            case "_HelpAction":  # pragma: no cover
+                return
+            case "_StoreAction":
+                self._unparse_store_action(action)
+            case "_StoreConstAction":
+                self._unparse_store_const_action(action)
+            case "_StoreFalseAction":
+                self._unparse_store_false_action(action)
+            case "_StoreTrueAction":
+                self._unparse_store_true_action(action)
+            case "_SubParsersAction":
+                self._unparse_sub_parsers_action(action)
+            case "_VersionAction":  # pragma: no cover
+                return
+            case "BooleanOptionalAction":
+                self._unparse_boolean_optional_action(action)
+            case _:  # pragma: no cover
+                message = (
+                    f"{self.__class__.__name__} does not yet support the "
+                    f"unparsing of {action_type} objects."
+                )
+                raise NotImplementedError(message)
 
     def _arg_is_default_and_help_is_suppressed(self, action: Action) -> bool:
         """


### PR DESCRIPTION
Undo the last of 8d15f4ab124bb067f5422538050dd7c70b414aa8.

* Use a match case statement in place of an if block.
* Replace Union types with X | Y syntax.

Also introduce support for Python 3.14.

Closes #16.

## Summary by Sourcery

Drop support for Python 3.9 and add compatibility with Python 3.14 while leveraging modern Python 3.10+ syntax throughout the codebase and updating CI, metadata, and docs accordingly.

New Features:
- Add support for Python 3.14

Enhancements:
- Replace lengthy if-elif chain in _unparse_action with match-case
- Switch Union/Optional type hints to PEP 604 `X | Y` syntax

Build:
- Raise minimum supported Python version to 3.10

CI:
- Remove Python 3.9 and add Python 3.14 in the CI test matrix

Documentation:
- Update Python version classifiers and badge to reflect support for 3.10–3.14

Tests:
- Adjust test type hints to use `X | Y` syntax instead of Optional or Union