### PR TITLE
Revert "ci: Ensure SSH client is installed"

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -29,9 +29,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Install openssh-client
-        run: sudo apt-get update && sudo apt-get install -y openssh-client
-
       - name: Python Semantic Release
         id: release
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3


### PR DESCRIPTION
This reverts commit 1993c3d6d66838354b26e92ea1518b0a3bbe23b9.

The real fix is in 1c21dd3b48e52af24c07fe9d0c83c2bf78606985.

## Summary by Sourcery

CI:
- Remove the explicit apt-based installation of openssh-client from the semantic-release GitHub Actions workflow.