### PR TITLE
fix: prevent crashes when unparsing count, extend, and append actions

### DIFF
--- a/reverse_argparse/reverse_argparse.py
+++ b/reverse_argparse/reverse_argparse.py
@@ -400,6 +400,8 @@ class ReverseArgumentParser:
         flag = self._get_option_string(action)
         if not isinstance(values, list):
             values = [values]
+        if not values:
+            return
         result = []
         if isinstance(values[0], list):
             for entry in values:
@@ -433,7 +435,11 @@ class ReverseArgumentParser:
             action:  The :class:`_CountAction` in question.
         """
         value = getattr(self._namespace, action.dest)
+        if value is None:
+            return
         count = value if action.default is None else (value - action.default)
+        if count <= 0:
+            return
         flag = self._get_option_string(action, prefer_short=True)
         if (
             len(flag) == SHORT_OPTION_LENGTH
@@ -494,7 +500,10 @@ class ReverseArgumentParser:
         values = getattr(self._namespace, action.dest)
         if values is not None:
             self._append_list_of_args(
-                [self._get_option_string(action), *values]
+                [
+                    self._get_option_string(action),
+                    *(quote_arg_if_necessary(str(value)) for value in values),
+                ]
             )
 
     def _unparse_boolean_optional_action(self, action: Action) -> None:

--- a/test/test_reverse_argparse.py
+++ b/test/test_reverse_argparse.py
@@ -503,6 +503,7 @@ def test__unparse_store_false_action(
             "--foo bar baz --foo bif",
             ["    --foo bar baz", "    --foo bif"],
         ),
+        (["--foo"], {"action": "append", "default": []}, "", []),
     ],
 )
 def test__unparse_append_action(
@@ -556,10 +557,16 @@ def test__unparse_append_const_action(args: str, expected: str | None) -> None:
             "-vv",
             "    -vv",
         ),
+        (["--verbose", "-v"], {"action": "count"}, "", None),
+        (["--verbose", "-v"], {"action": "count", "default": 0}, "", None),
+        (["--verbose", "-v"], {"action": "count", "default": 2}, "", None),
     ],
 )
 def test__unparse_count_action(
-    add_args: list[str], add_kwargs: dict[str, Any], args: str, expected: str
+    add_args: list[str],
+    add_kwargs: dict[str, Any],
+    args: str,
+    expected: str | None,
 ) -> None:
     """Ensure ``count`` actions are handled appropriately."""
     parser = ArgumentParser()
@@ -567,7 +574,7 @@ def test__unparse_count_action(
     namespace = parser.parse_args(shlex.split(args))
     unparser = ReverseArgumentParser(parser, namespace)
     unparser._unparse_count_action(action)
-    assert unparser._args[1:] == [expected]
+    assert unparser._args[1:] == ([expected] if expected is not None else [])
 
 
 @pytest.mark.parametrize(
@@ -645,13 +652,40 @@ def test__unparse_sub_parsers_action_nested() -> None:
     assert result == pretty
 
 
-def test__unparse_extend_action() -> None:
+@pytest.mark.parametrize(
+    ("add_args", "add_kwargs", "args", "expected"),
+    [
+        (
+            ["--foo"],
+            {"action": "extend", "nargs": "*"},
+            "--foo bar --foo baz bif",
+            "    --foo bar baz bif",
+        ),
+        (
+            ["--nums"],
+            {"action": "extend", "nargs": "+", "type": int},
+            "--nums 1 2",
+            "    --nums 1 2",
+        ),
+        (
+            ["--words"],
+            {"action": "extend", "nargs": "+"},
+            "--words 'a b' c",
+            "    --words 'a b' c",
+        ),
+    ],
+)
+def test__unparse_extend_action(
+    add_args: list[str],
+    add_kwargs: dict[str, Any],
+    args: str,
+    expected: str,
+) -> None:
     """Ensure ``extend`` actions are handled appropriately."""
     parser = ArgumentParser()
-    action = parser.add_argument("--foo", action="extend", nargs="*")
-    namespace = parser.parse_args(shlex.split("--foo bar --foo baz bif"))
+    action = parser.add_argument(*add_args, **add_kwargs)
+    namespace = parser.parse_args(shlex.split(args))
     unparser = ReverseArgumentParser(parser, namespace)
-    expected = "    --foo bar baz bif"
     unparser._unparse_extend_action(action)
     assert unparser._args[1:] == [expected]
 


### PR DESCRIPTION
**Type:  Bug**

## Description

Three of the action unparsers raise (or emit malformed output) on valid input that reaches them through the public `get_effective_command_line_invocation()`. I ran into these while reversing a parser that used `count`, `extend`, and `append` options, then reduced each to a minimal repro.

- `_unparse_count_action` builds the short flag with `flag[0] + flag[1] * count`. For a `count` option that was not given and whose default is `None`, the stored value is `None` and the multiplication raises `TypeError: can't multiply sequence by non-int of type 'NoneType'`. With a default of `0` (or a value equal to a nonzero default) `count` is `0`, so it emits a bare prefix like `-` instead of omitting the unused flag.
- `_unparse_extend_action` passes the stored values straight into `" ".join(...)`, so a typed option such as `type=int` raises `TypeError: sequence item 1: expected str instance, int found`. It also never calls `quote_arg_if_necessary`, unlike the `append` unparser, so a value containing spaces is emitted unquoted and the round trip breaks.
- `_unparse_append_action` indexes `values[0]` to detect the nested-list case, which raises `IndexError: list index out of range` when an `append` option with `default=[]` was not given (the `values is None` guard does not catch an empty list).

## Related Issues/PRs

None that I could find; I came across these while using the library.

## Motivation

`get_effective_command_line_invocation()` should either reproduce the invocation or omit an option that was not supplied. In these three cases it crashes or prints something that would not parse back, which defeats the point of the reconstructed command line.

## Implementation Details

Each fix is small and local to the action it concerns:

- `count`: return early when the value is `None`, and skip emitting anything when the effective count is `<= 0` (the flag was not given beyond its default).
- `extend`: quote each value with `quote_arg_if_necessary(str(value))`, matching what the `append` unparser already does. This fixes both the non-string crash and the unquoted-spaces round trip.
- `append`: return early when the normalized value list is empty, before the `values[0]` access.

I kept the changes minimal rather than refactoring the shared logic, but happy to consolidate if you would prefer.

## Testing

Added regression cases to the existing parametrized tests for all three actions (a not-given `count` with `None`/`0`/nonzero defaults, an `extend` with `type=int` and one with a space-containing value, and an `append` with `default=[]` that was not given). Confirmed each case failed before the change and passes after.

The full suite passes locally on Python 3.12:

```
75 passed in 0.07s
```

`ruff check`, `ruff format --check`, and `mypy` are also clean on both changed files.

## Documentation

No documentation changes; behavior of the public API is unchanged except that these inputs no longer crash or emit malformed output.

## Summary by Sourcery

Prevent crashes and malformed output when unparsing count, extend, and append actions from command-line invocations.

Bug Fixes:
- Skip emitting append options when the normalized value list is empty to avoid index errors.
- Avoid unparsing count options when the value is None or the effective count is non-positive, preventing type errors and stray flags.
- Quote and stringify extend action values before emitting them so non-string values and space-containing arguments are handled correctly.

Tests:
- Add parametrized regression tests covering edge cases for append, count, and extend actions, including absent options, defaults, and typed/space-containing values.